### PR TITLE
feat(web-ui): add resume landing page

### DIFF
--- a/apps/web-ui/src/pages/landing.astro
+++ b/apps/web-ui/src/pages/landing.astro
@@ -1,0 +1,30 @@
+---
+import Page from "../components/scaffold/page.astro";
+import Logo from "../components/Logo.astro";
+---
+
+<Page location="Home" title="Resume">
+  <div class="flex flex-col items-center text-neutral-100 pb-8">
+    <Logo height={160} width={160} />
+    <h1 class="mt-4 text-4xl font-semibold">Weston Novelli</h1>
+    <p class="text-lg text-neutral-300">Staff Software Engineer &ndash; UI</p>
+  </div>
+  <div class="grid gap-4">
+    <section class="bg-color1 rounded p-4 text-neutral-100">
+      <h2 class="text-xl font-semibold mb-2">About</h2>
+      <p>
+        UI engineer focused on building performant, accessible interfaces and
+        the systems that support them. Experienced delivering results across
+        product, design, and engineering teams.
+      </p>
+    </section>
+    <section class="bg-color1 rounded p-4 text-neutral-100">
+      <h2 class="text-xl font-semibold mb-2">Core Skills</h2>
+      <ul class="list-disc list-inside space-y-1">
+        <li>Typescript &amp; modern web frameworks</li>
+        <li>Microfrontends &amp; architecture</li>
+        <li>Design systems &amp; component libraries</li>
+      </ul>
+    </section>
+  </div>
+</Page>


### PR DESCRIPTION
## Summary
- add resume landing page using existing logo and color scheme
- remove navigation links from resume landing page per review feedback

## Testing
- `yarn install` *(fails: Request was cancelled fetching Yarn binaries)*
- `yarn build` *(fails: Request was cancelled fetching Yarn binaries)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prettier)*
- `npm run build` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689646bb0830832ea513c0e4b5c48f6a