### PR TITLE
Add PostHog integration and interest button

### DIFF
--- a/apps/web-ui/src/components/TalkMoreButton.astro
+++ b/apps/web-ui/src/components/TalkMoreButton.astro
@@ -1,0 +1,12 @@
+---
+---
+<button id="talk-more" class="px-4 py-2 rounded bg-color3 hover:shadow-lg hover:saturate-200">Want to talk more?</button>
+<script>
+  document.getElementById('talk-more')?.addEventListener('click', () => {
+    if (typeof posthog !== 'undefined') {
+      posthog.capture('want_to_talk_more');
+    }
+    alert('Thanks for your interest!');
+  });
+</script>
+

--- a/apps/web-ui/src/components/scaffold/page.astro
+++ b/apps/web-ui/src/components/scaffold/page.astro
@@ -11,6 +11,8 @@ interface Props {
 }
 
 const { location, title } = Astro.props;
+const POSTHOG_KEY = import.meta.env.PUBLIC_POSTHOG_KEY;
+const POSTHOG_HOST = import.meta.env.PUBLIC_POSTHOG_HOST ?? 'https://app.posthog.com';
 ---
 <html>
   <head>
@@ -19,6 +21,14 @@ const { location, title } = Astro.props;
     <Fonts />
     <link rel="icon" type="image/x-icon" href="/favicon.png">
     <title>Weston Novelli | {title} </title>
+    {POSTHOG_KEY && (
+      <>
+        <script src="https://cdn.posthog.com/posthog.js"></script>
+        <script is:inline>
+          posthog.init({JSON.stringify(POSTHOG_KEY)}, { api_host: {JSON.stringify(POSTHOG_HOST)} });
+        </script>
+      </>
+    )}
   </head>
   <body class="h-screen flex bg-color2">
     <Navbar location={location} class="hidden md:flex"/>

--- a/apps/web-ui/src/env.d.ts
+++ b/apps/web-ui/src/env.d.ts
@@ -1,2 +1,11 @@
 /// <reference path="../.astro/types.d.ts" />
 /// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  readonly PUBLIC_POSTHOG_KEY?: string;
+  readonly PUBLIC_POSTHOG_HOST?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/web-ui/src/pages/landing.astro
+++ b/apps/web-ui/src/pages/landing.astro
@@ -4,7 +4,7 @@ import Logo from "../components/Logo.astro";
 import TalkMoreButton from "../components/TalkMoreButton.astro";
 ---
 
-<Page location="Home" title="Resume">
+<Page location="Home" title="Staff Software Engineer">
   <div class="flex flex-col items-center text-neutral-100 pb-8">
     <Logo height={160} width={160} />
     <h1 class="mt-4 text-4xl font-semibold">Weston Novelli</h1>

--- a/apps/web-ui/src/pages/landing.astro
+++ b/apps/web-ui/src/pages/landing.astro
@@ -1,6 +1,7 @@
 ---
 import Page from "../components/scaffold/page.astro";
 import Logo from "../components/Logo.astro";
+import TalkMoreButton from "../components/TalkMoreButton.astro";
 ---
 
 <Page location="Home" title="Resume">
@@ -26,5 +27,8 @@ import Logo from "../components/Logo.astro";
         <li>Design systems &amp; component libraries</li>
       </ul>
     </section>
+  </div>
+  <div class="mt-4 flex justify-center">
+    <TalkMoreButton />
   </div>
 </Page>


### PR DESCRIPTION
## Summary
- integrate PostHog via CDN script in page scaffold
- add reusable "Want to talk more?" button capturing interest event
- expose interest button on landing page
- document PostHog env vars

## Testing
- `npm run build` *(fails: Cannot find module '@astrojs/react' imported from 'apps/web-ui/astro.config.mjs')*

------
https://chatgpt.com/codex/tasks/task_e_689658166ec8832e96afbec8942325bd