### PR TITLE
Update core skills card copy on homepage

### DIFF
--- a/apps/web-ui/src/pages/index.astro
+++ b/apps/web-ui/src/pages/index.astro
@@ -84,19 +84,19 @@ import Header from "../components/social-header.astro";
                             <ul class="space-y-4">
                                 <li class="flex items-center text-lg text-white/90">
                                     <div class="w-3 h-3 bg-color4 rounded-full mr-4 flex-shrink-0"></div>
+                                    <span>Agentic Engineering - enhancing development and products</span>
+                                </li>
+                                <li class="flex items-center text-lg text-white/90">
+                                    <div class="w-3 h-3 bg-color4 rounded-full mr-4 flex-shrink-0"></div>
+                                    <span>Product Engineering mindset - delivering value to customers</span>
+                                </li>
+                                <li class="flex items-center text-lg text-white/90">
+                                    <div class="w-3 h-3 bg-color4 rounded-full mr-4 flex-shrink-0"></div>
                                     <span>Type systems & modern web frameworks</span>
                                 </li>
                                 <li class="flex items-center text-lg text-white/90">
                                     <div class="w-3 h-3 bg-color4 rounded-full mr-4 flex-shrink-0"></div>
-                                    <span>Microfrontends & architecture</span>
-                                </li>
-                                <li class="flex items-center text-lg text-white/90">
-                                    <div class="w-3 h-3 bg-color4 rounded-full mr-4 flex-shrink-0"></div>
-                                    <span>AI-enabled features & automation</span>
-                                </li>
-                                <li class="flex items-center text-lg text-white/90">
-                                    <div class="w-3 h-3 bg-color4 rounded-full mr-4 flex-shrink-0"></div>
-                                    <span>Project delivery & team leadership</span>
+                                    <span>Building Architecture and Teams</span>
                                 </li>
                             </ul>
                         </div>


### PR DESCRIPTION
### Motivation
- Update the homepage Core Skills copy to reflect the new messaging and accurately represent current focus areas.

### Description
- Replace the four list items in `apps/web-ui/src/pages/index.astro` Core Skills card with: `Agentic Engineering - enhancing development and products`, `Product Engineering mindset - delivering value to customers`, `Type systems & modern web frameworks`, and `Building Architecture and Teams`.

### Testing
- Ran `git -C /workspace/hq status --short` to confirm the file was modified and present, which succeeded.
- Committed the change with `git -C /workspace/hq commit -m "Update core skills card copy on homepage"`, which succeeded.
- Verified the updated block with `nl -ba apps/web-ui/src/pages/index.astro | sed -n '82,110p'` to confirm the new lines, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1073a9bb34832eaf2d21fcb3f088ee)